### PR TITLE
Feature/auto attack prompt

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,10 +1,12 @@
 import { registerSettings, moduleName } from './settings.js';
 import { getGptReplyAsHtml } from './gpt-api.js';
+import * as utils from './utils.js';
 
 // Initialise the module and register the module settings
-Hooks.once('init', async function() {
-    console.log(`${moduleName} | Initialization`);
-	registerSettings();
+Hooks.once('init', async function () {
+  utils.log('Initialisation');
+  registerSettings();
+  // CONFIG.debug.hooks = true;
 });
 
 /*
@@ -69,81 +71,140 @@ dnd5e.dropItemSheetData
 
 // RollAttack
 // https://github.com/foundryvtt/dnd5e/wiki/Hooks#dnd5erollattack
-Hooks.on('dnd5e.rollAttack', async function(item, roll) {
-    
-    // Placeholders for the content we want to extract from the game object to construct our prompt 
-    // TODO Use a FormApplication to create a dialogue, allowing the GM to specify the details of the flavor text
-    // https://foundryvtt.wiki/en/development/guides/understanding-form-applications
-    // 1. Scene description
-    // At the moment, it will look for a journal page associated with the current scene. This won't always be available.
-    // 2. Actor - this will always be available due to the nature of it being hooked on an action
-    // 3. Target - targets may not always be idenitifed, and in some cases, there can be multiple targets. There should be a way
-    // for the GM to specific which are the targets of the attack
-    // I'm imaginging a list of checkboxes with each actor in the scene, ticking the box designates it as a target for the flavor text
-    // 4. Item is pretty straighforward 
-    // 5. Outcome. I think the final thing is a button with the outcome: critical miss, miss, hit, critical hit
+Hooks.on('dnd5e.rollAttack', async function (item, roll) {
+  // Placeholders for the content we want to extract from the game object to construct our prompt 
+  // TODO Use a FormApplication to create a dialogue, allowing the GM to specify the details of the flavor text
+  // https://foundryvtt.wiki/en/development/guides/understanding-form-applications
+  // 1. Scene description
+  // At the moment, it will look for a journal page associated with the current scene. This won't always be available.
+  // 2. Actor - this will always be available due to the nature of it being hooked on an action
+  // 3. Target - targets may not always be idenitifed, and in some cases, there can be multiple targets. There should be a way
+  // for the GM to specific which are the targets of the attack
+  // I'm imaginging a list of checkboxes with each actor in the scene, ticking the box designates it as a target for the flavor text
+  // 4. Item is pretty straighforward 
+  // 5. Outcome. I think the final thing is a button with the outcome: critical miss, miss, hit, critical hit
 
-    let _scene = game.scenes.active.journal.name;
-    let _actor = item.actor.name;
-    let _target = game.user.targets.first().document.name;
-    let _item = item.name;
+  // ! A source Item name and Actor name are the minimum requirements to generate a prompt.
+  // i.e. GPT has to be able to know who is doing some thing and what they're doing it with (at least for an attack)
+  // Targets and scene details are optional
 
-    let promptText = 'In a ' + _scene + ', ' + _actor + ' attacks ' + _target + ' with a ' + _item;
+  let _actorName = item?.actor?.name;
+  let _itemName = item?.name;
 
-    new Dialog({
-        title: "GPT Flavor Text",
-        content: promptText,
-        buttons: {
-          criticalMiss: {
-            label: "Critical Miss",
-            callback: () => {
-                respondTo(promptText +  ', but critically misses. Provide a brief narration of this in the second-person for the player.', []);
-            }
-          },
-          miss: {
-            label: "Miss",
-            callback: () => {
-                respondTo(promptText +  ', but misses. Provide a brief narration of this in the second-person for the player.', []);
-            }
-          },
-          hit: {
-            label: "Hit",
-            callback: () => {
-                respondTo(promptText +  ', and hits. Provide a brief narration of this in the second-person for the player.', []);
-            }
-          },
-          criticalHit: {
-            label: "Critical Hit",
-            callback: () => {
-                respondTo(promptText +  ', and critically hits. Provide a brief narration of this in the second-person for the player.', []);
-            }
-          },
-          killingBlow: {
-            label: "Killing Blow",
-            callback: () => {
-                respondTo(promptText +  ', and deals a killing blow, slaying the enemy. Provide a brief narration of this in the second-person for the player.', []);
-            }
-          }
-        },
-          default: 'buttonA',
-      }).render(true)
+  // If the actor or item aren't defined then we can just skip everything else
+  if (!_itemName) {
+    utils.logError('No attack item / spell available.')
+    return;
+  }
+  if (!_actorName) {
+    utils.logError('No actor defined.');
+    return;
+  }
 
+  let _sceneName = game?.scenes?.active?.journal?.name;
+  let _targetName = game?.user?.targets?.first()?.document?.name;
+  let _targetAc = game?.user?.targets?.first()?.document?._actor?.system?.attributes?.ac?.value;
 
+  // Guards with console errors
+  if (!_targetName) {
+    // Lack of target context shouldn't stop a prompt. Just log error for now
+    // TODO ? Add settings flag to suppress errors and warnings
+    utils.logError('No targets selected.')
+  }
+  if (!_sceneName) {
+    // Lack of scene context shouldn't stop a prompt. Just log error for now
+    // TODO ? Add settings flag to suppress errors and warnings
+    utils.logError('No scene defined.');
+  }
+
+  // let promptText = `${_actorName} attacks ${_targetName} using their ${_itemName} in a/an ${_sceneName}`
+  let promptText = `${_actorName} attacks ${_targetName ? _targetName + ' ' : ''}using their ${_itemName} ${_sceneName ? 'in a/an ' + _sceneName : ''}`
+
+  //let promptText = 'In a ' + _sceneName + ', ' + _actorName + ' attacks ' + _targetName + ' with a ' + _itemName;
+  if (roll && _targetAc) {
+    respondTo(promptText + ', ' + getHitMissPrompt(roll, _targetAc) + '. Provide a brief narration of this in the second-person for the player.', []);
+    return;
+  }
+
+  new Dialog({
+    title: "GPT Flavor Text",
+    content: promptText,
+    buttons: {
+      criticalMiss: {
+        label: "Critical Miss",
+        callback: () => {
+          respondTo(promptText + ', but critically misses. Provide a brief narration of this in the second-person for the player.', []);
+        }
+      },
+      miss: {
+        label: "Miss",
+        callback: () => {
+          respondTo(promptText + ', but misses. Provide a brief narration of this in the second-person for the player.', []);
+        }
+      },
+      hit: {
+        label: "Hit",
+        callback: () => {
+          respondTo(promptText + ', and hits. Provide a brief narration of this in the second-person for the player.', []);
+        }
+      },
+      criticalHit: {
+        label: "Critical Hit",
+        callback: () => {
+          respondTo(promptText + ', and critically hits. Provide a brief narration of this in the second-person for the player.', []);
+        }
+      },
+      killingBlow: {
+        label: "Killing Blow",
+        callback: () => {
+          respondTo(promptText + ', and deals a killing blow, slaying the enemy. Provide a brief narration of this in the second-person for the player.', []);
+        }
+      }
+    },
+    default: 'buttonA',
+  }).render(true)
 });
+
+/**
+ * 
+ * @param     {D20Roll}   roll  The roll object for the attack. Used to check critical hit/miss as well as the roll value.
+ * @param     {number}    ac    The target's AC value.
+ * @returns   {string}    Modifier for the prompt describing a hit/miss and the confidence of it
+ */
+function getHitMissPrompt(roll, ac) {
+  // Handle criticals first
+  if (roll?.isCritical) {
+    if (roll?.isFumble) { return 'but critically misses in a dramatic fashion'; }
+    else { return 'and critically hits in a dramatic fashion'; }
+  }
+  // Return a string based on the hit or miss confidence
+  let value = roll.total - ac;
+  var str = '';
+  if (value >= 10) { str = 'and lands a very confident hit'; }
+  else if (value >= 5) { str = 'and hits'; }
+  else if (value >= 3) { str = 'and just barely lands a hit'; }
+  else if (value >= 0) { str = 'and lands a hit purely out to luck' }
+  else if (value > -3) { str = 'but barely misses due to slight ineptness or a hint of bad luck' }
+  else if (value > -5) { str = 'but misses with ineptness or bad luck' }
+  else if (value > -10) { str = 'but misses with dramatic ineptness or dramatically bad luck' }
+  else if (value <= -10) { str = 'but completely misses' }
+  else { utils.logError('Could not find an appropriate string for ' + value); } // Shouldn't hit this, so logs as an error
+  return str;
+}
 
 // RollDamage
 // https://github.com/foundryvtt/dnd5e/wiki/Hooks#dnd5erolldamage
-Hooks.on('dnd5e.rollDamage', async function(item, roll) {
-    
-        // Placeholders for the content we want to extract from the game object to construct our prompt 
-        let _scene = game.scenes.active.journal.name;
-        let _actor = item.actor.name;
-        let _target = game.user.targets.first().document.name;
-        let _item = item.name;
-    
-        let promptText = 'In a ' + _scene + ', ' + _actor + ' hits ' + _target + ' with a ' + _item;
-    
-        respondTo(promptText + '. Provide a brief narration of this in the second-person for the player.', []);
+Hooks.on('dnd5e.rollDamage', async function (item, roll) {
+
+  // Placeholders for the content we want to extract from the game object to construct our prompt 
+  let _scene = game.scenes.active.journal.name;
+  let _actor = item.actor.name;
+  let _target = game.user.targets.first().document.name;
+  let _item = item.name;
+
+  let promptText = 'In a ' + _scene + ', ' + _actor + ' hits ' + _target + ' with a ' + _item;
+
+  respondTo(promptText + '. Provide a brief narration of this in the second-person for the player.', []);
 
 });
 
@@ -154,74 +215,74 @@ Hooks.on('dnd5e.rollDamage', async function(item, roll) {
 // /w gpt your prompt
 
 Hooks.on('chatMessage', (chatLog, message, chatData) => {
-	const echoChatMessage = async (chatData, question) => {
-		const toGptHtml = '<span class="ask-chatgpt-to">To: GPT</span><br>';
-		chatData.content = `${toGptHtml}${question.replace(/\n/g, "<br>")}`;
-		await ChatMessage.create(chatData);
-	};
+  const echoChatMessage = async (chatData, question) => {
+    const toGptHtml = '<span class="ask-chatgpt-to">To: GPT</span><br>';
+    chatData.content = `${toGptHtml}${question.replace(/\n/g, "<br>")}`;
+    await ChatMessage.create(chatData);
+  };
 
-	let match;
+  let match;
 
-	const reWhisper = new RegExp(/^(\/w(?:hisper)?\s)(\[(?:[^\]]+)\]|(?:[^\s]+))\s*([^]*)/, "i");
-	match = message.match(reWhisper);
-	if (match) {
-		const gpt = 'gpt';
-		const userAliases = match[2].replace(/[[\]]/g, "").split(",").map(n => n.trim());
-		const question = match[3].trim();
-		if (userAliases.some(u => u.toLowerCase() === gpt)) {
-			const users = userAliases
-				.filter(n => n.toLowerCase() !== gpt)
-				.reduce((arr, n) => arr.concat(ChatMessage.getWhisperRecipients(n)), [game.user]);
+  const reWhisper = new RegExp(/^(\/w(?:hisper)?\s)(\[(?:[^\]]+)\]|(?:[^\s]+))\s*([^]*)/, "i");
+  match = message.match(reWhisper);
+  if (match) {
+    const gpt = 'gpt';
+    const userAliases = match[2].replace(/[[\]]/g, "").split(",").map(n => n.trim());
+    const question = match[3].trim();
+    if (userAliases.some(u => u.toLowerCase() === gpt)) {
+      const users = userAliases
+        .filter(n => n.toLowerCase() !== gpt)
+        .reduce((arr, n) => arr.concat(ChatMessage.getWhisperRecipients(n)), [game.user]);
 
-			// same error logic as in Foundry
-			if (!users.length) throw new Error(game.i18n.localize("ERROR.NoTargetUsersForWhisper"));
-			if (users.some(u => !u.isGM && u.id != game.user.id) && !game.user.can("MESSAGE_WHISPER")) {
-				throw new Error(game.i18n.localize("ERROR.CantWhisper"));
-			}
+      // same error logic as in Foundry
+      if (!users.length) throw new Error(game.i18n.localize("ERROR.NoTargetUsersForWhisper"));
+      if (users.some(u => !u.isGM && u.id != game.user.id) && !game.user.can("MESSAGE_WHISPER")) {
+        throw new Error(game.i18n.localize("ERROR.CantWhisper"));
+      }
 
-			chatData.type = CONST.CHAT_MESSAGE_TYPES.WHISPER;
-			chatData.whisper = users.map(u => u.id);
-			chatData.sound = CONFIG.sounds.notification;
-			echoChatMessage(chatData, question);
+      chatData.type = CONST.CHAT_MESSAGE_TYPES.WHISPER;
+      chatData.whisper = users.map(u => u.id);
+      chatData.sound = CONFIG.sounds.notification;
+      echoChatMessage(chatData, question);
 
-			respondTo(question, users);
+      respondTo(question, users);
 
-			// prevent further processing, since an unknown whisper target would trigger an error
-			return false;
-		}
-	}
+      // prevent further processing, since an unknown whisper target would trigger an error
+      return false;
+    }
+  }
 
-	const rePublic = new RegExp(/^(\/\?\s)\s*([^]*)/, "i");
-	match = message.match(rePublic);
-	if (match) {
-		const question = match[2].trim();
-		echoChatMessage(chatData, question);
+  const rePublic = new RegExp(/^(\/\?\s)\s*([^]*)/, "i");
+  match = message.match(rePublic);
+  if (match) {
+    const question = match[2].trim();
+    echoChatMessage(chatData, question);
 
-		respondTo(question, []);
+    respondTo(question, []);
 
-		// prevent further processing, since an unknown command would trigger an error
-		return false;
-	}
+    // prevent further processing, since an unknown command would trigger an error
+    return false;
+  }
 
-	return true;
+  return true;
 });
 
 async function respondTo(question, users) {
-	console.debug(`${moduleName} | respondTo(question = "${question}", users =`, users, ')');
-	try {
-		const reply = await getGptReplyAsHtml(question);
+  utils.logDebug('respondTo(question,users)', question, users);
+  try {
+    const reply = await getGptReplyAsHtml(question);
 
-		const abbr = "By ChatGPT. Statements may be false";
-		await ChatMessage.create({
-			user: game.user.id,
-			speaker: ChatMessage.getSpeaker({alias: 'GPT-Flavor-Text'}),
-			content: `<abbr title="${abbr}" class="ask-chatgpt-to fa-solid fa-microchip-ai"></abbr>
+    const abbr = "By ChatGPT. Statements may be false";
+    await ChatMessage.create({
+      user: game.user.id,
+      speaker: ChatMessage.getSpeaker({ alias: 'GPT-Flavor-Text' }),
+      content: `<abbr title="${abbr}" class="ask-chatgpt-to fa-solid fa-microchip-ai"></abbr>
 				<span class="ask-chatgpt-reply">${reply}</span>`,
-			whisper: users.map(u => u.id),
-			sound: CONFIG.sounds.notification,
-		});
-	} catch (e) {
-		console.error(`${moduleName} | Failed to provide response.`, e);
-		ui.notifications.error(e.message, {permanent: true, console: false});
-	}
+      whisper: users.map(u => u.id),
+      sound: CONFIG.sounds.notification,
+    });
+  } catch (e) {
+    utils.logError('Failed to provide response.', e);
+    ui.notifications.error(e.message, { permanent: true, console: false });
+  }
 }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,4 +1,4 @@
-import { registerSettings } from './settings.js';
+import { registerSettings, moduleName } from './settings.js';
 import { getGptReplyAsHtml } from './gpt-api.js';
 import * as utils from './utils.js';
 
@@ -121,7 +121,7 @@ Hooks.on('dnd5e.rollAttack', async function (item, roll) {
   let promptText = `${_actorName} attacks ${_targetName ? _targetName + ' ' : ''}using their ${_itemName} ${_sceneName ? 'in a/an ' + _sceneName : ''}`
 
   //let promptText = 'In a ' + _sceneName + ', ' + _actorName + ' attacks ' + _targetName + ' with a ' + _itemName;
-  if (roll && _targetAc) {
+  if (game.settings.get(moduleName, 'rollAttack-autoPrompt') && roll && _targetAc) {
     respondTo(promptText + ', ' + getHitMissPrompt(roll, _targetAc) + '. Provide a brief narration of this in the second-person for the player.', []);
     return;
   }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,4 +1,4 @@
-import { registerSettings, moduleName } from './settings.js';
+import { registerSettings } from './settings.js';
 import { getGptReplyAsHtml } from './gpt-api.js';
 import * as utils from './utils.js';
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -59,7 +59,7 @@ export const registerSettings = () => {
 		config: true,
 		type: Number,
 		default: 0,
-		range: {min: 0, max: 50},
+		range: { min: 0, max: 50 },
 	});
 
 	game.settings.register(moduleName, 'gameSystem', {
@@ -84,6 +84,17 @@ export const registerSettings = () => {
 		type: String,
 		default: gameSystems[game.settings.get(moduleName, 'gameSystem')].prompt,
 		onChange: () => console.log(`${moduleName} | ChatGPT prompt now is:`, getGamePromptSetting()),
+	});
+
+	// Flag to enable/disable auto prompts for attack rolls (will always show the dialog if disabled)
+	game.settings.register(moduleName, 'rollAttack-autoPrompt', {
+		name: 'Auto-prompts for attack rolls',
+		hint: 'Allow prompts to be automatically generated when enough info is available to do so.' +
+			'\n(Requires a target for the attack, and the target must have an AC value.)',
+		scope: 'world',
+		config: true,
+		type: Boolean,
+		default: true
 	});
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,18 @@
+
+import { moduleName } from './settings.js';
+/** UTILITY FUNCTIONS **/
+
+// Standardised console logging to allow us to filter console messages from this module
+export function log(msg = '', ...objs) {
+    console.log(`${moduleName} | ${msg}`, objs);
+}
+
+// Standardised/formatted error logging to specify errors from this module
+export function logError(msg = '', e = null) {
+    console.error(`${moduleName} | ${msg ?? '<No error details available>'}`, e)
+}
+
+// Standardised/formatted debug logging of a message and/or any number of objects
+export function logDebug(msg = '', ...objs) {
+    console.debug(`${moduleName} | ${msg}`, objs);
+}


### PR DESCRIPTION
(Sorry, I did a bad thing and snuck the utils additions in under the same commit.)

Added automatic generation of a prompt for attack rolls where
1. The auto prompt setting is enabled AND
2. The attack target is set AND
3. The attack target has an AC value
If these conditions are met then the prompt will be created automatically, with an added level of confidence/luck flavouring on the hit/miss.
If any of these checks fail then the prompt settings dialog will display for the user to manually select the details of the prompt.

Added setting to enable/disable auto prompt generation on attacks
![image](https://github.com/rexmortus/gpt-flavor-text/assets/77598444/ec0eb43c-4a8c-4e10-824d-b7399a93789d)

Added utils functions for logging against the module name, making it easier to filter console messages against the module.
![image](https://github.com/rexmortus/gpt-flavor-text/assets/77598444/136897c2-7e72-4131-8e1c-da8b2638dae3)
