### PR TITLE
Add HP and Status Effects flavor

### DIFF
--- a/scripts/lib/chat.js
+++ b/scripts/lib/chat.js
@@ -10,7 +10,7 @@ export async function respondTo(prompt, users) {
             user: game.user.id,
             speaker: ChatMessage.getSpeaker({ alias: "GPT-Flavor-Text" }),
             content: `<abbr class="ask-chatgpt-to fa-solid fa-spinner fa-spin"></abbr>
-        <span class="ask-chatgpt-reply">Fetching flavor text</span>`,
+        <span class="ask-chatgpt-reply">Fetching flavor text</span><p><small>${prompt}</small></p>`,
             whisper: users.map((u) => u.id),
         }).then(function (result) {
             return result;

--- a/scripts/lib/hooks/rollAttack/rollAttack.js
+++ b/scripts/lib/hooks/rollAttack/rollAttack.js
@@ -31,7 +31,7 @@ export async function main(item, roll) {
 
     if (game.settings.get(moduleName, "rollAttack-autoPrompt") && roll && target) {
         let prompt = createPrompt(actor, item, target, scene, roll);
-        chat.respondTo(prompt, gmUser);
+        chat.respondTo(prompt, [gmUser]);
     } else {
         new AttackRollPromptFormApplication(
             game.scenes.active,

--- a/scripts/lib/hooks/rollAttack/rollAttack.prompt.js
+++ b/scripts/lib/hooks/rollAttack/rollAttack.prompt.js
@@ -4,7 +4,7 @@
  */
 import { utils } from "../../index.js";
 
-const promptInstructions = ". Provide a brief narration of this in the second-person for the player.";
+const promptInstructions = "Provide a brief narration of this in the second-person for the player.";
 
 export const createPrompt = (actor, item, target, scene, roll) => {
     let _actorName = actor?.name;
@@ -35,9 +35,9 @@ export const createPrompt = (actor, item, target, scene, roll) => {
         utils.logError("No scene defined.");
     }
 
-    let prompt = `${_actorName} attacks ${_targetName ? _targetName + " " : ""} using their ${_itemName} ${
+    let prompt = `${_actorName}, ${getHealthPrompt(actor)} ${getEffectsPrompt(actor)}, attacks ${_targetName}, ${getHealthPrompt(target)} ${getEffectsPrompt(target)}, using their ${_itemName} ${
         _sceneName ? "in a/an " + _sceneName : ", "
-    } ${getHitMissPrompt(roll, target)} ${promptInstructions}`;
+    } ${getHitMissPrompt(roll, target)}. ${promptInstructions}`;
 
     utils.log(prompt);
 
@@ -85,4 +85,57 @@ function getHitMissPrompt(roll, target) {
         utils.logError("Could not find an appropriate string for " + value);
     } // Shouldn't hit this, so logs as an error
     return str;
+}
+
+/**
+ *
+ * @param     {actor}    actor    The actor
+ * @returns   {string}    Modifier for the prompt describing a relevative health of the actor
+ */
+function getHealthPrompt(actor) {
+
+    let _actorTotalHP = actor?.system?.attributes?.hp?.max;
+    let _actorCurrentHP = actor?.system?.attributes?.hp?.value;
+
+    let percentage = _actorCurrentHP / _actorTotalHP;
+    var str = "";
+
+    if (percentage == 1) {
+        str = "in perfect health"
+    } else if (percentage >= 0.80) {
+        str = "in excellent health"
+    } else if (percentage >= 0.60 && percentage < 0.80) {
+        str = "in good health"
+    } else if (percentage >= 0.40 && percentage < 0.60) {
+        str = "in middling health"
+    } else if (percentage >= 0.20 && percentage < 0.40) {
+        str = "in poor health"
+    } else if (percentage >= 0.00 && percentage < 0.20) {
+        str = "in terrible health"
+    } else {
+        utils.logError("Could not find an appropriate string for " + percentage)
+    }
+    return str;
+
+}
+
+/**
+ *
+ * @param     {actor}    actor    The actor
+ * @returns   {string}    Modifier for the prompt describing a relevative health of the actor
+ */
+function getEffectsPrompt(actor) {
+
+    var str = "(with status effects: ";
+    
+    if (actor.effects.contents.length == 0) {
+       return ""; 
+    } else {
+        actor.effects.forEach(function(effect) {
+            str += `${effect.label}, `
+        });
+    }
+
+    return str += ')';
+
 }


### PR DESCRIPTION
This pull request adds a basic version of "HP Flavor":

![image](https://github.com/rexmortus/gpt-flavor-text/assets/308827/fe968fcf-5420-45dc-8c50-5773a9d231c6)

It also adds a basic version of "Status Effects Flavor"

![image](https://github.com/rexmortus/gpt-flavor-text/assets/308827/ef658c23-d459-4602-b256-63430026daf5)

It also fixes a bug where auto-generated prompts didn't work because the gmUser wasn't passed inside an array.

This branch generates prompts like this:

![image](https://github.com/rexmortus/gpt-flavor-text/assets/308827/1d458223-c07b-460f-a66c-fe66d720c608)

Which gives us flavor text like this:

![image](https://github.com/rexmortus/gpt-flavor-text/assets/308827/aee45cf8-94e1-439a-a800-e84d291b9f58)